### PR TITLE
Add Gemma support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## 🚀 Features
 
 Model Support:
+  * Gemma Models
   * Llama & Llama2 Models
   * Mistral & Mixtral Models
   * GPT-2 Models

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/ModelSupport.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/ModelSupport.java
@@ -3,6 +3,9 @@ package com.github.tjake.jlama.model;
 import com.github.tjake.jlama.model.bert.BertConfig;
 import com.github.tjake.jlama.model.bert.BertModel;
 import com.github.tjake.jlama.model.bert.BertTokenizer;
+import com.github.tjake.jlama.model.gemma.GemmaConfig;
+import com.github.tjake.jlama.model.gemma.GemmaModel;
+import com.github.tjake.jlama.model.gemma.GemmaTokenizer;
 import com.github.tjake.jlama.model.gpt2.GPT2Config;
 import com.github.tjake.jlama.model.gpt2.GPT2Model;
 import com.github.tjake.jlama.model.gpt2.GPT2Tokenizer;
@@ -35,6 +38,7 @@ public class ModelSupport {
 
 
     public enum ModelType {
+        GEMMA(GemmaModel.class, GemmaConfig.class, GemmaTokenizer.class),
         MISTRAL(MistralModel.class, MistralConfig.class, LlamaTokenizer.class),
         MIXTRAL(MixtralModel.class, MixtralConfig.class, LlamaTokenizer.class),
         LLAMA(LlamaModel.class, LlamaConfig.class, LlamaTokenizer.class),

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/RMSNorm.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/RMSNorm.java
@@ -9,8 +9,15 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 public class RMSNorm extends LayerNorm {
+    private final float weightAdjustment;
+
     public RMSNorm(AbstractModel m, AbstractTensor weights) {
+        this(m, weights, 0.0f);
+    }
+
+    public RMSNorm(AbstractModel m, AbstractTensor weights, float weightAdjustment) {
         super(m, null, weights);
+        this.weightAdjustment = weightAdjustment;
     }
 
     @Override
@@ -34,7 +41,7 @@ public class RMSNorm extends LayerNorm {
         // normalize and scale
         AbstractTensor output = input.copyShape();
         for (int j = offset; j < limit; j++) {
-            output.set(weights.get(j) * (ss * input.get(j)), j);
+            output.set((weightAdjustment + weights.get(j)) * (ss * input.get(j)), j);
         }
         return output;
     }

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaConfig.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaConfig.java
@@ -1,0 +1,29 @@
+package com.github.tjake.jlama.model.gemma;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tjake.jlama.math.ActivationFunction;
+import com.github.tjake.jlama.safetensors.Config;
+
+public class GemmaConfig extends Config {
+    @JsonCreator
+    public GemmaConfig( @JsonProperty("max_position_embeddings") int contextLength,
+            @JsonProperty("hidden_size") int embeddingLength,
+            @JsonProperty("intermediate_size") int hiddenLength,
+            @JsonProperty("num_attention_heads") int numberOfHeads,
+            @JsonProperty("num_key_value_heads") int numberOfKeyValueHeads,
+            @JsonProperty("num_hidden_layers") int numberOfLayers,
+            @JsonProperty("rms_norm_eps") float layerNormEps,
+            @JsonProperty("vocab_size") int vocabularySize,
+            @JsonProperty("bos_token_id") int bosToken,
+            @JsonProperty("eos_token_id") int eosToken,
+            @JsonProperty("hidden_act") ActivationFunction.Type activationFunction,
+            @JsonProperty(value = "rope_theta") Double ropeFreqsTheta,
+            @JsonProperty(value = "rope_scaling") Map<String,String> ropeScaling) {
+        super(contextLength, embeddingLength, hiddenLength, numberOfHeads, numberOfKeyValueHeads, numberOfLayers, layerNormEps, vocabularySize, bosToken, eosToken, activationFunction,
+                ropeFreqsTheta == null ? 10000.0 : ropeFreqsTheta,
+                ropeScaling == null ? 1.0 : Double.parseDouble(ropeScaling.get("factor")));
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModel.java
@@ -1,0 +1,112 @@
+package com.github.tjake.jlama.model.gemma;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.tjake.jlama.model.CausalSelfAttention;
+import com.github.tjake.jlama.model.LayerNorm;
+import com.github.tjake.jlama.model.MLPBlock;
+import com.github.tjake.jlama.model.RMSNorm;
+import com.github.tjake.jlama.model.TransformerBlock;
+import com.github.tjake.jlama.model.functions.EmbedInput;
+import com.github.tjake.jlama.model.functions.SampleOutput;
+import com.github.tjake.jlama.model.llama.LlamaModel;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.DType;
+import com.github.tjake.jlama.safetensors.WeightLoader;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+import com.github.tjake.jlama.tensor.AbstractTensor;
+import com.github.tjake.jlama.tensor.operations.TensorOperationsProvider;
+
+public class GemmaModel extends LlamaModel {
+    private static final Logger logger = LoggerFactory.getLogger(GemmaModel.class);
+
+    public GemmaModel(Config config, WeightLoader weights, Tokenizer tokenizer, DType workingDType, DType workingQType, Optional<DType> modelQType)
+    {
+        super(config, weights, tokenizer, workingDType, workingQType, modelQType);
+    }
+
+    public GemmaModel(InferenceType inferenceType, Config config, WeightLoader weights, Tokenizer tokenizer, DType workingDType, DType workingQType, Optional<DType> modelQType)
+    {
+        super(inferenceType, config, weights, tokenizer, workingDType, workingQType, modelQType);
+    }
+
+    private AbstractTensor wte;
+
+    @Override
+    protected TransformerBlock[] loadTransformerBlockWeights() {
+        DType qType = modelQType.orElse(this.modelDType);
+        if (qType != this.modelDType) {
+            logger.info("Quantizing model with {} - Please hold...", qType);
+        }
+
+        TransformerBlock[] transformerBlocks = new TransformerBlock[c.getNumberOfLayers()];
+
+        IntStream.range(c.layerStart(), c.layerEnd()).parallel().forEach(i -> {
+            String base = "model.layers." + i + ".";
+            String prefix = base + "self_attn.";
+            CausalSelfAttention attention = new CausalSelfAttention(this,
+                    weights.load(prefix + "q_proj.weight", c.offset()).quantize(qType),
+                    weights.load(prefix + "k_proj.weight", c.offset()).quantize(qType),
+                    weights.load(prefix + "v_proj.weight", c.offset()).quantize(qType),
+                    weights.load(prefix + "o_proj.weight", c.offset()).quantize(qType));
+
+            prefix = base + "mlp.";
+
+            MLPBlock mlp = new MLPBlock(this, c.activationFunction,
+                    weights.load(prefix + "gate_proj.weight", c.offset()).quantize(qType), //w1
+                    weights.load(prefix + "down_proj.weight").quantize(qType), //w2
+                    weights.load(prefix + "up_proj.weight", c.offset()).quantize(qType));  //w3
+
+            transformerBlocks[i] = new TransformerBlock( this,
+                    new RMSNorm(this, weights.load(base + "input_layernorm.weight", c.offset()).quantize(qType), 1.0f),
+                    attention,
+                    new RMSNorm(this, weights.load(base + "post_attention_layernorm.weight", c.offset()).quantize(qType), 1.0f),
+                    mlp);
+        });
+
+        return transformerBlocks;
+    }
+
+    @Override
+    protected EmbedInput loadInputWeights() {
+
+        if (wte == null)
+            wte = weights.load("model.embed_tokens.weight", c.offset()).quantize(workingDType); //Don't quantize this, it's used for the embedding layer
+
+        return (inputToken, position) -> {
+            AbstractTensor embedding = makeTensor(c.embeddingLength);
+            embedding.copyFrom(wte, wte.getOffset(inputToken, c.embeddingSegmentStart()), embedding.getOffset(c.embeddingSegmentStart()), c.embeddingSegmentLength());
+
+            //This is important for Gemma, but not for Llama
+            TensorOperationsProvider.get().scale((float) Math.pow(c.embeddingLength, 0.5), embedding, c.embeddingSegmentStart(), c.embeddingSegmentLength());
+
+            return embedding;
+        };
+    }
+
+    @Override
+    protected SampleOutput loadOutputWeights() {
+        DType qType = modelQType.orElse(this.modelDType);
+
+        if (wte == null)
+            wte = weights.load("model.embed_tokens.weight", c.offset()).quantize(workingDType); //Don't quantize this, it's used for the embedding layer
+
+        final LayerNorm layerNorm = new RMSNorm(this, weights.load("model.norm.weight").quantize(qType), 1.0f);
+
+        return new SampleOutput() {
+            @Override
+            public LayerNorm getOutputLayerNorm() {
+                return layerNorm;
+            }
+
+            @Override
+            public AbstractTensor getOutputLogitsWeights() {
+                return wte;
+            }
+        };
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaTokenizer.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaTokenizer.java
@@ -1,0 +1,58 @@
+package com.github.tjake.jlama.model.gemma;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.github.tjake.jlama.safetensors.tokenizer.BPETokenizer;
+
+public class GemmaTokenizer extends BPETokenizer {
+    static final String SPIECE_UNDERLINE = "▁";
+
+    private final int byteFallbackEncodingOffset;
+
+    public GemmaTokenizer(Path modelRoot) {
+        super(modelRoot);
+
+        this.byteFallbackEncodingOffset = 217;
+    }
+
+    @Override
+    protected long encodeCharacterAsToken(byte c) {
+        return Byte.toUnsignedLong(c) + byteFallbackEncodingOffset;
+    }
+
+    @Override
+    protected Optional<Character> maybeDecodeTokenAsCharacter(long id)
+    {
+        //Handle ascii codes (shifted in vocab)
+        if (model.byteFallback && id >= byteFallbackEncodingOffset && id < 256 + byteFallbackEncodingOffset) {
+            char c = (char)(id - byteFallbackEncodingOffset);
+            return Optional.of(c);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected String preProcess(String sentence)
+    {
+        return sentence.replace(" ", SPIECE_UNDERLINE);
+    }
+
+    @Override
+    protected String postProcess(String sentence) {
+        return sentence.stripLeading();
+    }
+
+    @Override
+    protected String postProcessToken(String decoded) {
+        if (decoded == null)
+            decoded = model.unkToken;
+
+        decoded = decoded.replaceAll("</?s>", "");
+        decoded = decoded.replaceAll(SPIECE_UNDERLINE, " ");
+
+        return decoded;
+    }
+}

--- a/jlama-net/src/test/java/com/github/tjake/jlama/net/JlamaServiceTest.java
+++ b/jlama-net/src/test/java/com/github/tjake/jlama/net/JlamaServiceTest.java
@@ -1,5 +1,6 @@
 package com.github.tjake.jlama.net;
 
+import com.github.tjake.jlama.math.ActivationFunction;
 import com.github.tjake.jlama.model.AbstractModel;
 import com.github.tjake.jlama.model.TransformerBlock;
 import com.github.tjake.jlama.model.functions.EmbedInput;
@@ -102,7 +103,7 @@ public class JlamaServiceTest {
 
     class MockConfig extends Config {
         public MockConfig(int contextLength, int embeddingLength, int hiddenLength, int numberOfHeads, int numberOfLayers, float layerNormEps) {
-            super(contextLength, embeddingLength, hiddenLength, numberOfHeads, numberOfHeads, numberOfLayers, layerNormEps, 32000, 1, 2, 10000.0, 1.0);
+            super(contextLength, embeddingLength, hiddenLength, numberOfHeads, numberOfHeads, numberOfLayers, layerNormEps, 32000, 1, 2, ActivationFunction.Type.SILU, 10000.0, 1.0);
         }
     }
 

--- a/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestCorrectness.java
+++ b/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestCorrectness.java
@@ -3,6 +3,7 @@ package com.github.tjake.jlama.model;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.tjake.jlama.math.FloatConversions;
 import com.github.tjake.jlama.math.VectorMath;
+import com.github.tjake.jlama.model.gemma.GemmaTokenizer;
 import com.github.tjake.jlama.model.gpt2.GPT2Tokenizer;
 import com.github.tjake.jlama.model.llama.LlamaTokenizer;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
@@ -193,4 +194,25 @@ public class TestCorrectness {
 
         Assert.assertArrayEquals(expected, actual);
     }
+
+    @Test
+    public void testGemmaTokenizer() throws IOException
+    {
+        String modelPrefix = "../models/gemma-2b";
+        Assume.assumeTrue(Files.exists(Paths.get(modelPrefix)));
+
+        Tokenizer tokenizer = new GemmaTokenizer(Paths.get(modelPrefix));
+
+        String p = "Write me a poem about Machine Learning.";
+
+        long[] actual = tokenizer.encode(p);
+        long[] expected = new long[]{5559,    682,    476,  19592,   1105,  13403,  14715, 235265};
+
+        String d = tokenizer.decode(actual);
+        System.out.println(d);
+
+        Assert.assertArrayEquals(expected, actual);
+        Assert.assertEquals(p, d);
+    }
+
 }

--- a/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestModels.java
+++ b/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestModels.java
@@ -4,6 +4,9 @@ import com.github.tjake.jlama.math.VectorMath;
 import com.github.tjake.jlama.model.bert.BertConfig;
 import com.github.tjake.jlama.model.bert.BertModel;
 import com.github.tjake.jlama.model.bert.BertTokenizer;
+import com.github.tjake.jlama.model.gemma.GemmaConfig;
+import com.github.tjake.jlama.model.gemma.GemmaModel;
+import com.github.tjake.jlama.model.gemma.GemmaTokenizer;
 import com.github.tjake.jlama.model.mixtral.MixtralConfig;
 import com.github.tjake.jlama.model.mixtral.MixtralModel;
 import com.github.tjake.jlama.safetensors.*;
@@ -124,6 +127,19 @@ public class TestModels {
             MixtralModel model = new MixtralModel(c, weights, tokenizer, DType.F32, DType.I8, Optional.empty());
             String prompt = "Simply put, the theory of relativity states that";
             model.generate(UUID.randomUUID(), prompt, 0.7f, 256, false, makeOutHandler());
+        }
+    }
+
+    @Test
+    public void GemmaRun() throws Exception {
+        String modelPrefix = "../models/gemma-2b";
+        Assume.assumeTrue(Files.exists(Paths.get(modelPrefix)));
+        try (WeightLoader weights = SafeTensorSupport.loadWeights(Path.of(modelPrefix).toFile())) {
+            GemmaTokenizer tokenizer = new GemmaTokenizer(Paths.get(modelPrefix));
+            GemmaConfig c = om.readValue(new File(modelPrefix + "/config.json"), GemmaConfig.class);
+            GemmaModel model = new GemmaModel(c, weights, tokenizer, DType.F32, DType.F32, Optional.empty());
+            String prompt = "Simply put, the theory of relativity states that";
+            model.generate(UUID.randomUUID(), prompt, 0.9f, 256, false, makeOutHandler());
         }
     }
 


### PR DESCRIPTION
```
./run-cli.sh download -t $HF_TOKEN google/gemma-2b

./run-cli.sh complete -p "#write a quicksort program in python" -t 0.3 -q Q4 models/gemma-2b 
> Working memory type = F32, Quantized memory type = I8
> Quantizing model with Q4 - Please hold...
#write a quicksort program in python

def quicksort(arr):
    if len(arr)<=1:
        return arr
    else:
        pivot = arr[0]
        less = quicksort([x for x in arr[1:] if x <= pivot])
        greater = quicksort([x for x in arr[1:] if x > pivot])
        return(less+ [pivot]+ greater)

print(quicksort([1,2,3,4,5,6,7,8,9]))


elapsed: 12s, 114.666664ms per token
```