### PR TITLE
fix typo in error message `tokenizer.jsom`

### DIFF
--- a/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/tokenizer/BPETokenizer.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/tokenizer/BPETokenizer.java
@@ -36,7 +36,7 @@ public abstract class BPETokenizer implements Tokenizer {
 
     protected BPETokenizer(Path modelRoot) {
         Preconditions.checkArgument(
-                modelRoot.resolve("tokenizer.json").toFile().exists(), "No tokenizer.jsom found in " + modelRoot);
+                modelRoot.resolve("tokenizer.json").toFile().exists(), "No tokenizer.json found in " + modelRoot);
 
         try {
             this.model = SafeTensorSupport.loadTokenizer(modelRoot);

--- a/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/tokenizer/WordPieceTokenizer.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/tokenizer/WordPieceTokenizer.java
@@ -42,7 +42,7 @@ public class WordPieceTokenizer implements Tokenizer {
 
     public WordPieceTokenizer(Path modelRoot) {
         Preconditions.checkArgument(
-                modelRoot.resolve("tokenizer.json").toFile().exists(), "No tokenizer.jsom found in " + modelRoot);
+                modelRoot.resolve("tokenizer.json").toFile().exists(), "No tokenizer.json found in " + modelRoot);
 
         try {
             this.model = SafeTensorSupport.loadTokenizer(modelRoot);


### PR DESCRIPTION
Fix the typos in error message when tokenizer.json doesn't exist