### PR TITLE
#62 global preview feature description

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ Add LLM Inference directly to your Java application.
 
 ## 🔬 Quick Start
 
+### 😌 Easy Start [optional]
+
+jlama relies on Java 21 preview features. You can enable the features globally with:
+
+```shell
+export JDK_JAVA_OPTIONS="--add-modules jdk.incubator.vector --enable-preview"
+```
+
 ### 🕵️‍♀️ How to use as a local client (with jbang!)
 Jlama includes a command line tool that makes it easy to use.
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,6 @@ Add LLM Inference directly to your Java application.
 
 ## 🔬 Quick Start
 
-### 😌 Easy Start [optional]
-
-jlama relies on Java 21 preview features. You can enable the features globally with:
-
-```shell
-export JDK_JAVA_OPTIONS="--add-modules jdk.incubator.vector --enable-preview"
-```
-
 ### 🕵️‍♀️ How to use as a local client (with jbang!)
 Jlama includes a command line tool that makes it easy to use.
 
@@ -129,6 +121,15 @@ If you would like to embed Jlama without langchain4j, add the following [maven](
 </dependency>
 
 ```
+
+jlama uses Java 21 preview features. You can enable the features globally with:
+
+```shell
+export JDK_JAVA_OPTIONS="--add-modules jdk.incubator.vector --enable-preview"
+```
+or enable the preview features by configuring maven compiler and failsafe plugins.
+
+
 
 Then you can use the Model classes to run models:
 


### PR DESCRIPTION
Jlama will not work without configuring the preview features and adding the jvector module.

A global configuration option has been added to the readme which fixes the standalone jlama demo as well as Maven projects.