### PR TITLE
Overloads download method to specify progress

### DIFF
--- a/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/SafeTensorSupport.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/SafeTensorSupport.java
@@ -310,7 +310,7 @@ public class SafeTensorSupport {
         return qPath;
     }
 
-    public static File maybeDownloadModel(String modelDir, String fullModelName) throws IOException {
+    public static File maybeDownloadModel(String modelDir, String fullModelName, TriConsumer<String, Long, Long> progressReporter) throws IOException {
         String[] parts = fullModelName.split("/");
         if (parts.length == 0 || parts.length > 2) {
             throw new IllegalArgumentException("Model must be in the form owner/name");
@@ -327,7 +327,11 @@ public class SafeTensorSupport {
             name = parts[1];
         }
 
-        return maybeDownloadModel(modelDir, Optional.ofNullable(owner), name, true, Optional.empty(), Optional.empty(), Optional.empty());
+        return maybeDownloadModel(modelDir, Optional.ofNullable(owner), name, true, Optional.empty(), Optional.empty(), Optional.ofNullable(progressReporter));
+    }
+
+    public static File maybeDownloadModel(String modelDir, String fullModelName) throws IOException {
+        return maybeDownloadModel(modelDir, fullModelName, null);
     }
 
     public static Path constructLocalModelPath(String modelDir, String owner, String modelName) {


### PR DESCRIPTION
Overloads download method to specify progress. 

Notifying progress is something that might sound informative task, but in production environments might be a key operation, for example in case of a Java FX you might want to print a progress bar in the screen, or in a Kubernetes environment you might want to add a health check (Readiness check) till the download is completed.

Of course, there are multiple ways of doing it, but the library already provides the interface, so the best way is doing using it.

Instead of using the whole download method with all parameters, I have just added a new method that takes the model, where to store it and also let you redefine the progress bar. In this way, it is easier for developer to cover this use case and not having to pass all the arguments.

This is a helping method as developers can still use the full parameters method to do it.