### PR TITLE
feat(116): adding feat to remove model through cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Other:
   download             Downloads a HuggingFace model - use owner/name format
   list                 Lists local models
   quantize             Quantize the specified model
+  rm                   Removes local model
 ```
 
 

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/JlamaCli.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/JlamaCli.java
@@ -50,6 +50,7 @@ public class JlamaCli implements Runnable {
         cli.addSubcommand("quantize", new QuantizeCommand());
         cli.addSubcommand("cluster-coordinator", new ClusterCoordinatorCommand());
         cli.addSubcommand("cluster-worker", new ClusterWorkerCommand());
+        cli.addSubcommand("rm", new RemoveCommand());
 
         cli.getHelpSectionMap().remove(SECTION_KEY_COMMAND_LIST_HEADING);
         cli.getHelpSectionMap().put(SECTION_KEY_COMMAND_LIST, getCommandRenderer());
@@ -66,7 +67,7 @@ public class JlamaCli implements Runnable {
         Map<String, List<String>> sections = new LinkedHashMap<>();
         sections.put("Inference", asList("chat", "restapi", "complete"));
         sections.put("Distributed Inference", asList("cluster-coordinator", "cluster-worker"));
-        sections.put("Other", asList("download", "list", "quantize"));
+        sections.put("Other", asList("download", "list", "quantize", "rm"));
         CommandGroupRenderer renderer = new CommandGroupRenderer(sections);
         return renderer;
     }

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
@@ -16,7 +16,6 @@
 package com.github.tjake.jlama.cli.commands;
 
 import com.github.tjake.jlama.cli.JlamaCli;
-import com.github.tjake.jlama.model.ModelSupport;
 import com.github.tjake.jlama.safetensors.SafeTensorSupport;
 import picocli.CommandLine;
 
@@ -27,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.FileVisitResult;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Objects;
 
 @CommandLine.Command(name = "rm", description = "Removes local model", abbreviateSynopsis = true)
 public class RemoveCommand extends JlamaCli {

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 T Jake Luciani
+ *
+ * The Jlama Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.tjake.jlama.cli.commands;
+
+import com.github.tjake.jlama.cli.JlamaCli;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.safetensors.SafeTensorSupport;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.FileVisitResult;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+
+@CommandLine.Command(name = "rm", description = "Removes local model", abbreviateSynopsis = true)
+public class RemoveCommand extends JlamaCli {
+    @CommandLine.Option(names = {
+            "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})", defaultValue = "models")
+    protected File modelDirectory = new File("models");
+
+    @CommandLine.Parameters(index = "0", arity = "1", paramLabel = "<model name>", description = "The huggingface model owner/name pair")
+    protected String modelName;
+
+    @Override
+    public void run() {
+        String owner = SimpleBaseCommand.getOwner(modelName);
+        String name = SimpleBaseCommand.getName(modelName);
+
+        Path modelPath = SafeTensorSupport.constructLocalModelPath(modelDirectory.getAbsolutePath(), owner, name);
+
+        if (!modelPath.toFile().exists()) {
+            System.err.println("Model not found: " + modelPath);
+            System.exit(1);
+        }
+
+        try {
+            Files.walkFileTree(modelPath, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path modelPath, IOException exc) throws IOException {
+                    Files.delete(modelPath);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("Model successfully removed: " + modelPath);
+        } catch (IOException e) {
+            System.err.println("Failed to delete model: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/SimpleBaseCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/SimpleBaseCommand.java
@@ -69,7 +69,7 @@ public class SimpleBaseCommand extends JlamaCli {
 
     static String getName(String modelName) {
         String[] parts = modelName.split("/");
-        if (parts.length == 0 || parts.length > 2) {
+        if (parts.length != 2) {
             System.err.println("Model name must be in the form owner/name");
             System.exit(1);
         }


### PR DESCRIPTION
I added functionality to jlama-cli to be able to remove a local model using a new "rm" command. For example, jlama rm tjake/Llama-3.2-1B-Instruct-JQ4.

closes #116 