### PR TITLE
Changing default model home directory for CLI

### DIFF
--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/JlamaCli.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/JlamaCli.java
@@ -21,11 +21,13 @@ import ch.qos.logback.core.ConsoleAppender;
 import com.github.tjake.jlama.cli.commands.*;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.*;
 
 import java.util.*;
+import java.io.File;
 
 import static java.util.Arrays.asList;
 import static picocli.CommandLine.Help.Column.Overflow.*;
@@ -33,6 +35,8 @@ import static picocli.CommandLine.Model.UsageMessageSpec.*;
 
 @Command(name = "jlama", sortOptions = false, headerHeading = "Usage:%n", synopsisHeading = "%n", descriptionHeading = "%nDescription:%n%n", parameterListHeading = "%nParameters:%n", optionListHeading = "%nCommand Options:%n", mixinStandardHelpOptions = true, usageHelpAutoWidth = true, requiredOptionMarker = '*', description = "Jlama is a modern LLM inference engine for Java!\nQuantized models are maintained at https://hf.co/tjake\n\nChoose from the available commands:", defaultValueProvider = PropertiesDefaultProvider.class)
 public class JlamaCli implements Runnable {
+    public static final String DEFAULT_MODEL_DIRECTORY = setupDefaultModelDirectory();
+
     static {
         setupLogging();
     }
@@ -56,7 +60,7 @@ public class JlamaCli implements Runnable {
         cli.getHelpSectionMap().put(SECTION_KEY_COMMAND_LIST, getCommandRenderer());
 
         String[] pargs = args.length == 0 ? new String[] { "-h" } : args;
-        cli.parseWithHandler(new RunLast(), pargs);
+        cli.execute(pargs);
     }
 
     @Override
@@ -186,7 +190,7 @@ public class JlamaCli implements Runnable {
         logEncoder.setPattern("%msg%n");
         logEncoder.start();
 
-        ConsoleAppender logConsoleAppender = new ConsoleAppender();
+        ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();
         logConsoleAppender.setContext(logCtx);
         logConsoleAppender.setName("console");
         logConsoleAppender.setEncoder(logEncoder);
@@ -195,5 +199,19 @@ public class JlamaCli implements Runnable {
         root.addAppender(logConsoleAppender);
         root.setAdditive(false);
         root.setLevel(Boolean.getBoolean("jlama.debug") ? Level.DEBUG : Level.INFO);
+    }
+
+    private static String setupDefaultModelDirectory() {
+        String envHome = System.getenv("JLAMA_MODEL_HOME");
+        String propHome = System.getProperty("jlama.model.home");
+        String defaultHome = System.getProperty("user.home", "") + File.separator + ".jlama" + File.separator + "models";
+
+        if (envHome != null && !envHome.isEmpty()) {
+            return envHome;
+        } else if (propHome != null && !propHome.isEmpty()) {
+            return propHome;
+        } else {
+            return defaultHome;
+        }
     }
 }

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/DownloadCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/DownloadCommand.java
@@ -25,8 +25,8 @@ import static com.github.tjake.jlama.cli.commands.SimpleBaseCommand.getOwner;
 @CommandLine.Command(name = "download", description = "Downloads a HuggingFace model - use owner/name format", abbreviateSynopsis = true)
 public class DownloadCommand extends JlamaCli {
     @CommandLine.Option(names = {
-        "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})", defaultValue = "models")
-    protected File modelDirectory = new File("models");
+        "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})")
+    protected File modelDirectory = new File(JlamaCli.DEFAULT_MODEL_DIRECTORY);
 
     @CommandLine.Option(names = {
         "--branch" }, paramLabel = "ARG", description = "The branch to download from (default: ${DEFAULT-VALUE})", defaultValue = "main")

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/ListCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/ListCommand.java
@@ -27,8 +27,8 @@ import java.util.Objects;
 @CommandLine.Command(name = "list", description = "Lists local models", abbreviateSynopsis = true)
 public class ListCommand extends JlamaCli {
     @CommandLine.Option(names = {
-        "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})", defaultValue = "models")
-    protected File modelDirectory = new File("models");
+        "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})")
+    protected File modelDirectory = new File(JlamaCli.DEFAULT_MODEL_DIRECTORY);
 
     @Override
     public void run() {

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/RemoveCommand.java
@@ -30,8 +30,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 @CommandLine.Command(name = "rm", description = "Removes local model", abbreviateSynopsis = true)
 public class RemoveCommand extends JlamaCli {
     @CommandLine.Option(names = {
-            "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})", defaultValue = "models")
-    protected File modelDirectory = new File("models");
+            "--model-cache" }, paramLabel = "ARG", description = "The local directory for all downloaded models (default: ${DEFAULT-VALUE})")
+    protected File modelDirectory = new File(JlamaCli.DEFAULT_MODEL_DIRECTORY);
 
     @CommandLine.Parameters(index = "0", arity = "1", paramLabel = "<model name>", description = "The huggingface model owner/name pair")
     protected String modelName;

--- a/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/SimpleBaseCommand.java
+++ b/jlama-cli/src/main/java/com/github/tjake/jlama/cli/commands/SimpleBaseCommand.java
@@ -39,8 +39,8 @@ public class SimpleBaseCommand extends JlamaCli {
     protected DownloadSection downloadSection = new DownloadSection();
 
     @CommandLine.Option(names = {
-        "--model-cache" }, paramLabel = "ARG", description = "The local directory for downloaded models (default: ${DEFAULT-VALUE})", defaultValue = "models")
-    protected File modelDirectory = new File("models");
+        "--model-cache" }, paramLabel = "ARG", description = "The local directory for downloaded models (default: ${DEFAULT-VALUE})")
+    protected File modelDirectory = new File(JlamaCli.DEFAULT_MODEL_DIRECTORY);
 
     @CommandLine.Parameters(index = "0", arity = "1", paramLabel = "<model name>", description = "The huggingface model owner/name pair")
     protected String modelName;
@@ -108,7 +108,7 @@ public class SimpleBaseCommand extends JlamaCli {
                 Optional.ofNullable(owner),
                 name,
                 downloadWeights,
-                Optional.ofNullable(URLEncoder.encode(branch)),
+                Optional.ofNullable(URLEncoder.encode(branch, "UTF-8")),
                 Optional.ofNullable(authToken),
                 getProgressConsumer()
             );


### PR DESCRIPTION
This change moves the default model cache directory from "models" which is a relative path. It checks for the model path in the following order:

1. Environment Variable set as JLAMA_MODEL_HOME.
2. Configuration Property with the key jlama.model.home.
3. Static path as {USER_HOME}/.jlama/models

This will make it so you can run the jlama cli from any directory. The --model-cache command argument can still be used.

This does introduce a very small breaking change. Once this makes it into a release and a user upgrades, their commands might not work as expected because we are going to be looking at a new directory for models. 