### PR TITLE
Refactor ModelType Enum to Extensible Interface-Based

### DIFF
--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModel.java
@@ -25,6 +25,7 @@ import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
 import com.github.tjake.jlama.tensor.AbstractTensor;
+
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -63,7 +64,7 @@ public class BertModel extends AbstractModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.BERT;
+        return ModelSupport.getModelType("BERT");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModelType.java
@@ -1,0 +1,23 @@
+package com.github.tjake.jlama.model.bert;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class BertModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return BertModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return BertConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return BertTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModel.java
@@ -26,10 +26,11 @@ import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
 import com.github.tjake.jlama.tensor.AbstractTensor;
 import com.github.tjake.jlama.tensor.operations.TensorOperationsProvider;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 public class GemmaModel extends LlamaModel {
     private static final Logger logger = LoggerFactory.getLogger(GemmaModel.class);
@@ -67,7 +68,7 @@ public class GemmaModel extends LlamaModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.GEMMA;
+        return ModelSupport.getModelType("GEMMA");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma/GemmaModelType.java
@@ -1,0 +1,23 @@
+package com.github.tjake.jlama.model.gemma;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class GemmaModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return GemmaModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return GemmaConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return GemmaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma2/Gemma2Model.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma2/Gemma2Model.java
@@ -68,7 +68,7 @@ public class Gemma2Model extends LlamaModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.GEMMA2;
+        return ModelSupport.getModelType("GEMMA2");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma2/Gemma2ModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gemma2/Gemma2ModelType.java
@@ -1,0 +1,24 @@
+package com.github.tjake.jlama.model.gemma2;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.gemma.GemmaTokenizer;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class Gemma2ModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return Gemma2Model.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return Gemma2Config.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return GemmaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gpt2/GPT2Model.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gpt2/GPT2Model.java
@@ -18,9 +18,12 @@ package com.github.tjake.jlama.model.gpt2;
 import com.github.tjake.jlama.model.*;
 import com.github.tjake.jlama.model.functions.EmbedInput;
 import com.github.tjake.jlama.model.functions.SampleOutput;
-import com.github.tjake.jlama.safetensors.*;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.DType;
+import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
 import com.github.tjake.jlama.tensor.AbstractTensor;
+
 import java.util.Optional;
 
 public class GPT2Model extends AbstractModel {
@@ -43,7 +46,7 @@ public class GPT2Model extends AbstractModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.GPT2;
+        return ModelSupport.getModelType("GPT2");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/gpt2/GPT2ModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/gpt2/GPT2ModelType.java
@@ -1,0 +1,23 @@
+package com.github.tjake.jlama.model.gpt2;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class GPT2ModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return GPT2Model.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return GPT2Config.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return GPT2Tokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/granite/GraniteModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/granite/GraniteModel.java
@@ -58,7 +58,7 @@ public class GraniteModel extends LlamaModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.GRANITE;
+        return ModelSupport.getModelType("GRANITE");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/granite/GraniteModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/granite/GraniteModelType.java
@@ -1,0 +1,24 @@
+package com.github.tjake.jlama.model.granite;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.gpt2.GPT2Tokenizer;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class GraniteModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return GraniteModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return GraniteConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return GPT2Tokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModel.java
@@ -26,10 +26,11 @@ import com.github.tjake.jlama.tensor.AbstractTensor;
 import com.github.tjake.jlama.tensor.operations.TensorOperationsProvider;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 public class LlamaModel extends AbstractModel {
     private static final Logger logger = LoggerFactory.getLogger(LlamaModel.class);
@@ -60,7 +61,7 @@ public class LlamaModel extends AbstractModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.LLAMA;
+        return ModelSupport.getModelType("LLAMA");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModelType.java
@@ -1,0 +1,23 @@
+package com.github.tjake.jlama.model.llama;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class LlamaModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return LlamaModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return LlamaConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return LlamaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/mistral/MistralModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/mistral/MistralModel.java
@@ -21,6 +21,7 @@ import com.github.tjake.jlama.safetensors.Config;
 import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
 import java.util.Optional;
 
 public class MistralModel extends LlamaModel {
@@ -50,6 +51,6 @@ public class MistralModel extends LlamaModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.MISTRAL;
+        return ModelSupport.getModelType("MISTRAL");
     }
 }

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/mistral/MistralModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/mistral/MistralModelType.java
@@ -1,0 +1,24 @@
+package com.github.tjake.jlama.model.mistral;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.llama.LlamaTokenizer;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class MistralModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return MistralModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return MistralConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return LlamaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/mixtral/MixtralModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/mixtral/MixtralModel.java
@@ -22,10 +22,11 @@ import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
 import com.github.tjake.jlama.tensor.AbstractTensor;
-import java.util.Optional;
-import java.util.stream.IntStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 public class MixtralModel extends MistralModel {
     private static final Logger logger = LoggerFactory.getLogger(MixtralModel.class);
@@ -55,7 +56,7 @@ public class MixtralModel extends MistralModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.MIXTRAL;
+        return ModelSupport.getModelType("MIXTRAL");
     }
 
     @Override

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/mixtral/MixtralModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/mixtral/MixtralModelType.java
@@ -1,0 +1,24 @@
+package com.github.tjake.jlama.model.mixtral;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.llama.LlamaTokenizer;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class MixtralModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return MixtralModel.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return MixtralConfig.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return LlamaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/qwen2/Qwen2Model.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/qwen2/Qwen2Model.java
@@ -107,6 +107,6 @@ public class Qwen2Model extends LlamaModel {
 
     @Override
     public ModelSupport.ModelType getModelType() {
-        return ModelSupport.ModelType.QWEN2;
+        return ModelSupport.getModelType("QWEN2");
     }
 }

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/qwen2/Qwen2ModelType.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/qwen2/Qwen2ModelType.java
@@ -1,0 +1,24 @@
+package com.github.tjake.jlama.model.qwen2;
+
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.llama.LlamaTokenizer;
+import com.github.tjake.jlama.safetensors.Config;
+import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
+
+public class Qwen2ModelType implements ModelSupport.ModelType {
+    @Override
+    public Class<? extends AbstractModel> getModelClass() {
+        return Qwen2Model.class;
+    }
+
+    @Override
+    public Class<? extends Config> getConfigClass() {
+        return Qwen2Config.class;
+    }
+
+    @Override
+    public Class<? extends Tokenizer> getTokenizerClass() {
+        return LlamaTokenizer.class;
+    }
+}

--- a/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/SafeTensorSupport.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/safetensors/SafeTensorSupport.java
@@ -15,12 +15,10 @@
  */
 package com.github.tjake.jlama.safetensors;
 
-import static com.github.tjake.jlama.util.JsonSupport.om;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
-import com.github.tjake.jlama.model.ModelSupport.ModelType;
+import com.github.tjake.jlama.model.ModelSupport;
 import com.github.tjake.jlama.safetensors.tokenizer.TokenizerModel;
 import com.github.tjake.jlama.tensor.AbstractTensor;
 import com.github.tjake.jlama.tensor.Q4ByteBufferTensor;
@@ -30,6 +28,9 @@ import com.github.tjake.jlama.util.HttpSupport;
 import com.github.tjake.jlama.util.ProgressReporter;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -39,8 +40,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.github.tjake.jlama.util.JsonSupport.om;
 
 public class SafeTensorSupport {
     private static final Logger logger = LoggerFactory.getLogger(SafeTensorSupport.class);
@@ -102,11 +102,11 @@ public class SafeTensorSupport {
         return new Weights(metadata, tensorInfoMap, safeBuf.slice(), Optional.empty());
     }
 
-    public static ModelType detectModel(File configFile) throws IOException {
+    public static ModelSupport.ModelType detectModel(File configFile) throws IOException {
         JsonNode rootNode = om.readTree(configFile);
         if (!rootNode.has("model_type")) throw new IllegalArgumentException("Config missing model_type field.");
 
-        return ModelType.valueOf(rootNode.get("model_type").textValue().toUpperCase());
+        return ModelSupport.getModelType(rootNode.get("model_type").textValue().toUpperCase());
     }
 
     public static WeightLoader loadWeights(File baseDir) {

--- a/jlama-net/src/test/java/com/github/tjake/jlama/net/JlamaServiceTest.java
+++ b/jlama-net/src/test/java/com/github/tjake/jlama/net/JlamaServiceTest.java
@@ -197,7 +197,7 @@ public class JlamaServiceTest {
 
         @Override
         public ModelSupport.ModelType getModelType() {
-            return ModelSupport.ModelType.LLAMA;
+            return ModelSupport.getModelType("LLAMA");
         }
 
         @Override

--- a/jlama-tests/src/test/java/com/github/tjake/jlama/model/Mocks.java
+++ b/jlama-tests/src/test/java/com/github/tjake/jlama/model/Mocks.java
@@ -129,7 +129,7 @@ public class Mocks {
 
         @Override
         public ModelSupport.ModelType getModelType() {
-            return ModelSupport.ModelType.LLAMA;
+            return ModelSupport.getModelType("LLAMA");
         }
 
         @Override


### PR DESCRIPTION
Hey, I’ve been messing around with this project and ran into a snag—I can’t easily add my own custom models. The LLM model structure’s a bit tricky for me to wrap my head around, so I’m not super comfy trying to add new models myself. It’d be awesome if there was a way for users to drop in their own models without waiting for official support.


# Description

This PR refactors the ModelType enum to an interface to make it extensible allowing new model types to be added without modifying existing code.

# Motivation
New model types can be added via new ModelType implementations and registered without changing existing code.
```
ModelSupport.ModelType modelType = new ModelSupport.ModelType() {
    @Override
    public Class<? extends AbstractModel> getModelClass() {
        return Qwen2Model.class;
    }
    @Override
    public Class<? extends Config> getConfigClass() {
        return Qwen2Config.class;
    }
    @Override
    public Class<? extends Tokenizer> getTokenizerClass() {
        return LlamaTokenizer.class;
    }
};

ModelSupport.register("QWEN3", modelType);
AbstractModel model = ModelSupport.loadEmbeddingModel(new File("Qwen_Qwen3-Embedding-0.6B"), DType.F32, DType.I8);
  ```


