### PR TITLE
Add getDirty to TensorCache avoiding clearing tensors when not needed

### DIFF
--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/AbstractModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/AbstractModel.java
@@ -245,7 +245,7 @@ public abstract class AbstractModel implements Generator {
     }
 
     protected AbstractTensor maybeQuantize(AbstractTensor t) {
-        AbstractTensor t2 = c.tensorCache.get(t.dType(), t.shape());
+        AbstractTensor t2 = c.tensorCache.getDirty(t.dType(), t.shape());
         t2.copyFrom(t, 0, 0, Ints.checkedCast(t.size()));
         return t2;
     }

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/llama/LlamaModel.java
@@ -23,6 +23,7 @@ import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.WeightLoader;
 import com.github.tjake.jlama.safetensors.tokenizer.Tokenizer;
 import com.github.tjake.jlama.tensor.AbstractTensor;
+import com.github.tjake.jlama.tensor.TensorCache;
 import com.github.tjake.jlama.tensor.operations.TensorOperationsProvider;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
@@ -89,11 +90,9 @@ public class LlamaModel extends AbstractModel {
                 return embedding;
             } else {
                 AbstractTensor at = wte.slice(true, inputToken);
-                AbstractTensor embedding = at.copyShape();
-
+                AbstractTensor embedding = TensorCache.instance.getDirty(at.dType(), at.shape());
                 // Always copy the entire embedding
                 embedding.copyFrom(at, 0, 0, c.embeddingLength);
-
                 return embedding;
             }
         };

--- a/jlama-core/src/main/java/com/github/tjake/jlama/tensor/TensorCache.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/tensor/TensorCache.java
@@ -72,16 +72,8 @@ public class TensorCache {
         this.availableByShape = Maps.newConcurrentMap();
     }
 
-    public AbstractTensor get(DType dType, TensorShape shape) {
-        MpmcUnboundedXaddArrayQueue<AbstractTensor> availableQueue = availableByShape.computeIfAbsent(
-            new ShapeKey(dType, shape),
-            queueFactory
-        );
-        AbstractTensor t = availableQueue.poll();
-
-        if (t != null) return t;
-
-        t = switch (dType) {
+    private AbstractTensor internalGet(DType dType, TensorShape shape){
+        AbstractTensor t = switch (dType) {
             case F32 -> new FloatBufferTensor(shape);
             case F16 -> new Float16BufferTensor(shape);
             case BF16 -> new BFloat16BufferTensor(shape);
@@ -89,20 +81,50 @@ public class TensorCache {
             case Q4 -> new Q4ByteBufferTensor(shape);
             default -> throw new RuntimeException("Unsupported tensor type: " + dType);
         };
-
-        // Assign to this cache or just over allocate
         if (currentBytes.addAndGet(t.size()) < bytesCapacity) {
             t.setOwnerCache(this);
         } else {
             logger.debug("Full!");
             currentBytes.addAndGet(-t.size());
         }
-
         return t;
     }
 
+    /**
+     * @return a tensor of a specific shape but possibly reused so it is up to the user to clear it. This is
+     * useful when the user knows they will overwrite the entire array
+     */
+    public AbstractTensor<?,?> getDirty(DType dType, TensorShape shape){
+        MpmcUnboundedXaddArrayQueue<AbstractTensor> availableQueue = availableByShape.computeIfAbsent(
+                new ShapeKey(dType, shape),
+                queueFactory
+        );
+        AbstractTensor<?,?> t = availableQueue.poll();
+        if (t != null) {
+            return t;
+        }
+        return internalGet(dType, shape);
+    }
+
+    /**
+     *
+     * @return returns a tensor of the given type and shape, if the cache was full
+     * the ownerCache will be null.
+     */
+    public AbstractTensor get(DType dType, TensorShape shape) {
+        MpmcUnboundedXaddArrayQueue<AbstractTensor> availableQueue = availableByShape.computeIfAbsent(
+                new ShapeKey(dType, shape),
+                queueFactory
+        );
+        AbstractTensor t = availableQueue.poll();
+        if (t != null) {
+            t.clear();
+            return t;
+        }
+        return internalGet(dType, shape);
+    }
+
     void release(AbstractTensor b) {
-        b.clear();
         MpmcUnboundedXaddArrayQueue<AbstractTensor> availableQueue = availableByShape.computeIfAbsent(
             new ShapeKey(b.dType(), b.shape()),
             queueFactory


### PR DESCRIPTION
The global static TensorCache has a get method, which attempts to return a tensor of same type and shape from the cache. Tensors are always cleared when they are released to the cache. However there are many cases, maybe most of them where we do not need to clear the tensor as the next user will typically overwrite it entirely:

{noformat}
Response{responseText='The best thing to do is to look for the plant that best suits your needs. Avocados are a type of fruit that are grown in the Americas, specifically in Mexico, Central America, and South America. They are known for their creamy, buttery texture and rich, nutty flavor.', responseTextWithSpecialTokens='The best thing to do is to look for the plant that best suits your needs. Avocados are a type of fruit that are grown in the Americas, specifically in Mexico, Central America, and South America. They are known for their creamy, buttery texture and rich, nutty flavor.', finishReason=STOP_TOKEN, promptTokens=65, generatedTokens=64, promptTimeMs=10018, generateTimeMs=10779}
tensorcache.dirtyget 130
tensorcache.get 111609
tensorcache.get.hit 111582
tensorcache.getdirty.hit 126
{noformat}

I only put the method in place in a couple of places as I dont have enough knoweldge to put it in place everywhere:

https://github.com/edwardcapriolo/deliverance/pull/4
