### PR TITLE
Feat: add LEAF model to Jlama

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Model Support:
   * Qwen2 Models
   * IBM Granite Models
   * GPT-2 Models
-  * BERT Models
+  * BERT Models (including LEAF embedding model)
   * BPE Tokenizers
   * WordPiece Tokenizers
 
@@ -259,6 +259,75 @@ You can simplify promptSupport using:
     System.out.println(r.responseText);
  }
 ```
+
+### 🔍 Semantic Search & Embeddings
+
+Jlama supports embedding models for semantic search, information retrieval, and code understanding. The [LEAF model](https://huggingface.co/MongoDB/mdbr-leaf-ir) is a compact, efficient embedding model optimized for information retrieval tasks - perfect for semantic code search, RAG applications, and understanding codebases semantically.
+
+**Use Cases:**
+- **Semantic Code Search**: Find code by meaning, not just keywords (e.g., "find all database connection methods")
+- **Code Understanding**: Understand relationships between classes, methods, and concepts in large codebases
+- **RAG Applications**: Build retrieval-augmented generation systems for code documentation and knowledge bases
+- **Information Retrieval**: Semantic search across documentation, code comments, and technical content
+
+```java
+import com.github.tjake.jlama.math.VectorMath;
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.functions.Generator;
+import com.github.tjake.jlama.safetensors.DType;
+import com.github.tjake.jlama.safetensors.SafeTensorSupport;
+import java.io.File;
+import java.io.IOException;
+
+public void semanticCodeSearch() throws IOException {
+    String modelName = "MongoDB/mdbr-leaf-ir";
+    String workingDirectory = "./models";
+    
+    // Download and load the LEAF embedding model
+    File localModelPath = SafeTensorSupport.maybeDownloadModel(workingDirectory, modelName);
+    AbstractModel embeddingModel = ModelSupport.loadEmbeddingModel(localModelPath, DType.F32, DType.F32);
+    
+    // Embed code snippets or documentation
+    String query = "database connection initialization";
+    String[] codeSnippets = {
+        "public class DatabaseConnection { private Connection conn; ... }",
+        "public void connectToDatabase(String url) { ... }",
+        "public class UserService { public void authenticate() { ... } }",
+        "Connection conn = DriverManager.getConnection(url, user, pass);"
+    };
+    
+    // Generate embeddings
+    float[] queryEmbedding = embeddingModel.embed(query, Generator.PoolingType.AVG);
+    
+    // Find most similar code snippet
+    float maxSimilarity = -1.0f;
+    String bestMatch = "";
+    for (String snippet : codeSnippets) {
+        float[] snippetEmbedding = embeddingModel.embed(snippet, Generator.PoolingType.AVG);
+        float similarity = VectorMath.cosineSimilarity(queryEmbedding, snippetEmbedding);
+        if (similarity > maxSimilarity) {
+            maxSimilarity = similarity;
+            bestMatch = snippet;
+        }
+    }
+    
+    System.out.println("Best match: " + bestMatch + " (similarity: " + maxSimilarity + ")");
+}
+```
+
+**Example: Building a Semantic Code Index**
+
+For tools like [Brokk AI](https://brokk.ai) that need to understand code semantically, you can use LEAF embeddings to:
+
+1. **Index codebase**: Generate embeddings for classes, methods, and documentation
+2. **Semantic search**: Find relevant code by meaning, not just text matching
+3. **Context retrieval**: Retrieve semantically similar code for LLM context
+4. **Code understanding**: Understand relationships and patterns across large codebases
+
+The LEAF model's compact size (23M parameters, 384 dimensions) makes it ideal for production use in IDEs and code analysis tools where low latency and memory efficiency are critical.
+
+See `jlama-core/src/main/java/com/github/tjake/jlama/examples/LeafModelExample.java` for a complete example.
 
 ## Devloping Jlama
 

--- a/jlama-core/src/main/java/com/github/tjake/jlama/examples/LeafModelExample.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/examples/LeafModelExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 T Jake Luciani
+ * Copyright 2025 Tiernan Lindauer
  *
  * The Jlama Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -23,151 +23,318 @@ import com.github.tjake.jlama.safetensors.DType;
 import com.github.tjake.jlama.safetensors.SafeTensorSupport;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Example demonstrating how to use the LEAF embedding model (MongoDB/mdbr-leaf-ir) with Jlama.
- * 
- * The LEAF model is a compact 6-layer, 384-dimensional BERT-based embedding model
- * optimized for information retrieval tasks.
- * 
+ *
+ * Improvements over a basic example:
+ *  - Robust error handling with clear messages and exit codes
+ *  - Optional L2 normalization of embeddings
+ *  - Batch-embedding helper (simple loop; toggleable parallel mode)
+ *  - Uses System.nanoTime() for accurate timing
+ *  - CLI flags for working directory, iterations, batch size, normalization, and parallel embedding
+ *
  * Usage:
- *   java -cp ... com.github.tjake.jlama.examples.LeafModelExample [model-directory]
- * 
- * If model-directory is not provided, it will attempt to download the model from HuggingFace.
+ *   java -cp ... com.github.tjake.jlama.examples.LeafModelExample [--model-dir DIR] [--iterations N]
+ *         [--batch-size N] [--normalize true|false] [--parallel true|false]
+ *
+ * Example:
+ *   java ... LeafModelExample --model-dir ./models --iterations 200 --batch-size 8 --normalize true
  */
 public class LeafModelExample {
-    
-    public static void main(String[] args) throws Exception {
-        String modelName = "MongoDB/mdbr-leaf-ir";
-        String workingDirectory = args.length > 0 ? args[0] : "./models";
-        
-        System.out.println("=== LEAF Model Integration Test ===");
+    private static final String DEFAULT_MODEL = "MongoDB/mdbr-leaf-ir";
+    private static final String DEFAULT_WORKDIR = "./models";
+    private static final int DEFAULT_ITERATIONS = 100;
+    private static final int DEFAULT_BATCH_SIZE = 1;
+    private static final boolean DEFAULT_NORMALIZE = false;
+    private static final boolean DEFAULT_PARALLEL = false;
+
+    public static void main(String[] args) {
+        // Simple CLI parsing
+        String modelName = DEFAULT_MODEL;
+        String workingDirectory = DEFAULT_WORKDIR;
+        int iterations = DEFAULT_ITERATIONS;
+        int batchSize = DEFAULT_BATCH_SIZE;
+        boolean l2Normalize = DEFAULT_NORMALIZE;
+        boolean parallel = DEFAULT_PARALLEL;
+
+        try {
+            for (int i = 0; i < args.length; i++) {
+                String a = args[i];
+                if ("--model-dir".equalsIgnoreCase(a) && i + 1 < args.length) {
+                    workingDirectory = args[++i];
+                } else if ("--iterations".equalsIgnoreCase(a) && i + 1 < args.length) {
+                    iterations = Integer.parseInt(args[++i]);
+                } else if ("--batch-size".equalsIgnoreCase(a) && i + 1 < args.length) {
+                    batchSize = Integer.parseInt(args[++i]);
+                } else if ("--normalize".equalsIgnoreCase(a) && i + 1 < args.length) {
+                    l2Normalize = Boolean.parseBoolean(args[++i]);
+                } else if ("--parallel".equalsIgnoreCase(a) && i + 1 < args.length) {
+                    parallel = Boolean.parseBoolean(args[++i]);
+                } else if ("--help".equalsIgnoreCase(a) || "-h".equalsIgnoreCase(a)) {
+                    printUsageAndExit(0);
+                } else {
+                    // ignored unknown flags for forward-compatibility
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Error parsing arguments: " + e.getMessage());
+            printUsageAndExit(2);
+        }
+
+        System.out.println("=== LEAF Model Integration Test (improved) ===");
         System.out.println("Model: " + modelName);
         System.out.println("Working directory: " + workingDirectory);
+        System.out.println("Iterations: " + iterations);
+        System.out.println("Batch size: " + batchSize);
+        System.out.println("L2-normalize: " + l2Normalize);
+        System.out.println("Parallel embedding: " + parallel);
         System.out.println();
-        
-        // Download the LEAF model or use existing if already downloaded
-        System.out.println("Downloading or locating LEAF model...");
-        File localModelPath = SafeTensorSupport.maybeDownloadModel(workingDirectory, modelName);
-        System.out.println("Model located at: " + localModelPath.getAbsolutePath());
-        System.out.println();
-        
-        // Load as embedding model
-        System.out.println("Loading model...");
-        AbstractModel model = ModelSupport.loadEmbeddingModel(localModelPath, DType.F32, DType.F32);
-        System.out.println("Model loaded successfully!");
-        System.out.println("Embedding dimensions: " + model.getConfig().embeddingLength);
-        System.out.println("Expected: 384");
-        System.out.println();
-        
-        if (model.getConfig().embeddingLength != 384) {
-            System.err.println("WARNING: Expected 384 dimensions but got " + model.getConfig().embeddingLength);
+
+        // Main flow wrapped in try/catch so we can exit cleanly on errors
+        try {
+            // Download or find model
+            System.out.println("Downloading or locating LEAF model...");
+            File localModelPath = SafeTensorSupport.maybeDownloadModel(workingDirectory, modelName);
+            if (localModelPath == null || !localModelPath.exists()) {
+                System.err.println("Failed to locate or download model at " + workingDirectory);
+                System.exit(3);
+            }
+            System.out.println("Model located at: " + localModelPath.getAbsolutePath());
+            System.out.println();
+
+            // Load embedding model (use F32 as the default dtype for LEAF)
+            System.out.println("Loading model...");
+            AbstractModel model = ModelSupport.loadEmbeddingModel(localModelPath, DType.F32, DType.F32);
+            if (model == null) {
+                System.err.println("ModelSupport.loadEmbeddingModel returned null - cannot proceed.");
+                System.exit(4);
+            }
+            System.out.println("Model loaded successfully!");
+            int embeddingLength = model.getConfig().embeddingLength;
+            System.out.println("Embedding dimensions reported by model: " + embeddingLength);
+            System.out.println("Expected (LEAF): 384");
+            if (embeddingLength != 384) {
+                System.err.println("WARNING: Expected 384 dimensions but got " + embeddingLength);
+            }
+            System.out.println();
+
+            // Samples for tests
+            String query1 = "What is artificial intelligence?";
+            String query2 = "Define artificial intelligence";
+            String query3 = "What is the weather today?";
+            List<String> batchInputs = Arrays.asList(
+                    "MongoDB stores data in documents",
+                    "PostgreSQL is a relational database",
+                    "The cat sat on the mat",
+                    "NoSQL databases are non-relational",
+                    "MongoDB uses BSON format"
+            );
+
+            // Pooling choice (explicit)
+            Generator.PoolingType poolingType = Generator.PoolingType.AVG; // LEAF does not include pooler layer; AVG is typical
+
+            // Single embedding test
+            System.out.println("=== Single Embedding Sanity Check ===");
+            float[] emb1 = safeEmbed(model, query1, poolingType);
+            if (emb1 == null) {
+                System.err.println("Embedding returned null for query: " + query1);
+                System.exit(5);
+            }
+            if (l2Normalize) l2NormalizeInPlace(emb1);
+            printEmbeddingStats(emb1);
+
+            // Verify shape
+            if (emb1.length != embeddingLength) {
+                System.err.printf(Locale.ROOT, "ERROR: Embedding length mismatch: expected %d got %d%n", embeddingLength, emb1.length);
+                System.exit(6);
+            }
+
+            // Similarity checks
+            System.out.println("=== Semantic Similarity Check ===");
+            float[] emb2 = safeEmbed(model, query2, poolingType);
+            float[] emb3 = safeEmbed(model, query3, poolingType);
+            if (emb2 == null || emb3 == null) {
+                System.err.println("ERROR: One of the test embeddings was null.");
+                System.exit(7);
+            }
+            if (l2Normalize) {
+                l2NormalizeInPlace(emb2);
+                l2NormalizeInPlace(emb3);
+            }
+            float sim12 = VectorMath.cosineSimilarity(emb1, emb2);
+            float sim13 = VectorMath.cosineSimilarity(emb1, emb3);
+            System.out.println("Similarity (Query1, Query2): " + String.format("%.4f", sim12));
+            System.out.println("Similarity (Query1, Query3): " + String.format("%.4f", sim13));
+            if (sim12 > sim13) {
+                System.out.println("✓ Related queries have higher similarity (as expected)");
+            } else {
+                System.out.println("⚠ WARNING: Related queries do NOT have higher similarity than unrelated one");
+            }
+            System.out.println();
+
+            // Small IR-like retrieval test
+            System.out.println("=== Small Information Retrieval Test ===");
+            float[] base = safeEmbed(model, "MongoDB is a NoSQL database", poolingType);
+            if (l2Normalize) l2NormalizeInPlace(base);
+
+            double maxSim = Double.NEGATIVE_INFINITY;
+            int bestIndex = -1;
+            for (int i = 0; i < batchInputs.size(); i++) {
+                float[] e = safeEmbed(model, batchInputs.get(i), poolingType);
+                if (l2Normalize) l2NormalizeInPlace(e);
+                double s = VectorMath.cosineSimilarity(base, e);
+                System.out.println(String.format("  [%d] Sim=%.4f - %s", i, s, batchInputs.get(i)));
+                if (s > maxSim) {
+                    maxSim = s;
+                    bestIndex = i;
+                }
+            }
+            System.out.println();
+            System.out.println("Best match index: " + bestIndex + " (expected 0, 3 or 4). Score: " + String.format("%.4f", maxSim));
+            if (bestIndex == 0 || bestIndex == 3 || bestIndex == 4) {
+                System.out.println("Best match is MongoDB-related (as expected)");
+            } else {
+                System.out.println("! WARNING: Best match is not MongoDB-related");
+            }
+            System.out.println();
+
+            // Batch embedding performance test
+            System.out.println("=== Performance / Throughput Test ===");
+            // Prepare repeated batch inputs to reach `iterations`
+            List<String> perfInputs = new ArrayList<>(batchSize * iterations);
+            for (int i = 0; i < iterations; i++) {
+                for (int b = 0; b < batchSize; b++) {
+                    // use the same short query for timing, but batch-based
+                    perfInputs.add(query1 + " " + i + "-" + b);
+                }
+            }
+
+            long t0 = System.nanoTime();
+            float[][] results;
+            if (batchSize <= 1) {
+                // single-embedding mode repeated
+                results = embedSequential(model, perfInputs, poolingType, l2Normalize, parallel);
+            } else {
+                // process in logical batches: for each iteration, embed batchSize items
+                results = embedInBatches(model, perfInputs, batchSize, poolingType, l2Normalize, parallel);
+            }
+            long t1 = System.nanoTime();
+
+            long elapsedNanos = t1 - t0;
+            double elapsedMillis = elapsedNanos / 1_000_000.0;
+            int totalEmbeddings = perfInputs.size();
+            double avgMs = elapsedMillis / totalEmbeddings;
+            System.out.println(String.format(Locale.ROOT, "Generated %d embeddings in %.2f ms (avg %.3f ms / embedding)",
+                    totalEmbeddings, elapsedMillis, avgMs));
+            System.out.println();
+
+            System.out.println("=== Test Complete ===");
+            System.exit(0);
+        } catch (Exception ex) {
+            System.err.println("Unexpected error during execution: " + ex.getMessage());
+            ex.printStackTrace(System.err);
+            System.exit(99);
         }
-        
-        // Test embedding generation with AVG pooling (LEAF doesn't have a pooler layer)
-        System.out.println("=== Testing Embedding Generation ===");
-        String query1 = "What is artificial intelligence?";
-        // LEAF model doesn't have a pooler layer, so we use AVG pooling
-        Generator.PoolingType poolingType = Generator.PoolingType.AVG;
-        float[] embedding1 = model.embed(query1, poolingType);
-        System.out.println("Query: " + query1);
-        System.out.println("Using AVG pooling (LEAF model doesn't have pooler layer)");
-        System.out.println("Embedding dimension: " + embedding1.length);
-        
-        // Verify embedding values are finite and not all zeros
+    }
+
+    // Simple usage message
+    private static void printUsageAndExit(int code) {
+        System.out.println("Usage: LeafModelExample [--model-dir DIR] [--iterations N] [--batch-size N] [--normalize true|false] [--parallel true|false]");
+        System.out.println("Defaults: model-dir=./models iterations=100 batch-size=1 normalize=false parallel=false");
+        System.exit(code);
+    }
+
+    // Safe wrapper for model.embed which handles exceptions and returns null on failure
+    private static float[] safeEmbed(AbstractModel model, String text, Generator.PoolingType poolingType) {
+        try {
+            // We assume the AbstractModel.embed(String, PoolingType) API exists as in the user's example
+            return model.embed(text, poolingType);
+        } catch (Throwable t) {
+            System.err.println("Error while embedding text: \"" + text + "\" -> " + t.getMessage());
+            t.printStackTrace(System.err);
+            return null;
+        }
+    }
+
+    // Sequential embedding for a list of inputs; optional parallelization via parallel flag
+    private static float[][] embedSequential(AbstractModel model, List<String> inputs, Generator.PoolingType poolingType, boolean normalize, boolean parallel) {
+        int n = inputs.size();
+        float[][] out = new float[n][];
+        if (parallel) {
+            // Simple parallel run using parallel streams — useful if the model implementation is thread-safe
+            // WARNING: Only enable this if you're confident the model supports concurrent inference
+            inputs.parallelStream().forEachOrdered((s) -> {
+                int idx = inputs.indexOf(s); // indexOf is O(n) but inputs are short here; for large lists prefer explicit indexing
+                float[] emb = safeEmbed(model, s, poolingType);
+                if (emb != null && normalize) l2NormalizeInPlace(emb);
+                out[idx] = emb;
+            });
+        } else {
+            for (int i = 0; i < n; i++) {
+                float[] emb = safeEmbed(model, inputs.get(i), poolingType);
+                if (emb != null && normalize) l2NormalizeInPlace(emb);
+                out[i] = emb;
+            }
+        }
+        return out;
+    }
+
+    // Process inputs in logical batches (simple loop), returns flattened results
+    private static float[][] embedInBatches(AbstractModel model, List<String> inputs, int batchSize, Generator.PoolingType poolingType, boolean normalize, boolean parallel) {
+        int total = inputs.size();
+        List<float[]> collected = new ArrayList<>(total);
+        for (int i = 0; i < total; i += batchSize) {
+            int end = Math.min(i + batchSize, total);
+            List<String> slice = inputs.subList(i, end);
+            // Here we call sequential embedding for the slice. If the model supports a native batch API, replace this.
+            float[][] batchResults = embedSequential(model, slice, poolingType, normalize, parallel);
+            for (float[] r : batchResults) collected.add(r);
+        }
+        return collected.toArray(new float[0][]);
+    }
+
+    // L2-normalize in-place
+    private static void l2NormalizeInPlace(float[] v) {
+        if (v == null) return;
+        double sum = 0.0;
+        for (float f : v) {
+            sum += (double) f * (double) f;
+        }
+        if (sum <= 0.0) return; // avoid division by zero
+        double norm = Math.sqrt(sum);
+        for (int i = 0; i < v.length; i++) {
+            v[i] = (float) ((double) v[i] / norm);
+        }
+    }
+
+    // Print basic stats on embedding vector
+    private static void printEmbeddingStats(float[] emb) {
         boolean hasNonZero = false;
         boolean allFinite = true;
         float min = Float.MAX_VALUE;
-        float max = Float.MIN_VALUE;
-        for (float v : embedding1) {
+        float max = -Float.MAX_VALUE;
+        double sum = 0.0;
+        if (emb == null || emb.length == 0) {
+            System.out.println("Embedding is empty or null.");
+            return;
+        }
+        for (float v : emb) {
             if (v != 0.0f) hasNonZero = true;
             if (!Float.isFinite(v)) allFinite = false;
             if (v < min) min = v;
             if (v > max) max = v;
+            sum += v;
         }
+        double mean = sum / emb.length;
+        System.out.println("Embedding length: " + emb.length);
         System.out.println("Has non-zero values: " + hasNonZero);
         System.out.println("All values finite: " + allFinite);
-        System.out.println("Value range: [" + min + ", " + max + "]");
-        System.out.println();
-        
-        // Test similarity between related texts
-        System.out.println("=== Testing Semantic Similarity ===");
-        String query2 = "Define artificial intelligence";
-        String query3 = "What is the weather today?";
-        float[] embedding2 = model.embed(query2, poolingType);
-        float[] embedding3 = model.embed(query3, poolingType);
-        
-        float similarity12 = VectorMath.cosineSimilarity(embedding1, embedding2);
-        float similarity13 = VectorMath.cosineSimilarity(embedding1, embedding3);
-        
-        System.out.println("Query 1: " + query1);
-        System.out.println("Query 2: " + query2);
-        System.out.println("Query 3: " + query3);
-        System.out.println();
-        System.out.println("Similarity between Query 1 and Query 2: " + String.format("%.4f", similarity12));
-        System.out.println("Similarity between Query 1 and Query 3: " + String.format("%.4f", similarity13));
-        System.out.println();
-        
-        if (similarity12 > similarity13) {
-            System.out.println("✓ Related queries have higher similarity (as expected)");
-        } else {
-            System.out.println("⚠ WARNING: Related queries should have higher similarity");
-        }
-        System.out.println();
-        
-        // Test with information retrieval examples
-        System.out.println("=== Information Retrieval Test ===");
-        String base = "MongoDB is a NoSQL database";
-        String[] examples = new String[] {
-            "MongoDB stores data in documents",
-            "PostgreSQL is a relational database",
-            "The cat sat on the mat",
-            "NoSQL databases are non-relational",
-            "MongoDB uses BSON format"
-        };
-        
-        float[] baseEmbedding = model.embed(base, poolingType);
-        float maxSimilarity = 0.0f;
-        String bestMatch = "";
-        int bestIndex = -1;
-        
-        System.out.println("Base query: " + base);
-        System.out.println();
-        for (int i = 0; i < examples.length; i++) {
-            float[] exampleEmbedding = model.embed(examples[i], poolingType);
-            float similarity = VectorMath.cosineSimilarity(baseEmbedding, exampleEmbedding);
-            System.out.println(String.format("  [%d] Similarity: %.4f - %s", i, similarity, examples[i]));
-            if (similarity > maxSimilarity) {
-                maxSimilarity = similarity;
-                bestMatch = examples[i];
-                bestIndex = i;
-            }
-        }
-        System.out.println();
-        System.out.println("Best match: [" + bestIndex + "] " + bestMatch + " (similarity: " + String.format("%.4f", maxSimilarity) + ")");
-        
-        // The best match should be one of the MongoDB-related examples (indices 0, 3, or 4)
-        if (bestIndex == 0 || bestIndex == 3 || bestIndex == 4) {
-            System.out.println("✓ Best match is MongoDB-related (as expected)");
-        } else {
-            System.out.println("⚠ WARNING: Best match should be MongoDB-related");
-        }
-        System.out.println();
-        
-        // Performance test
-        System.out.println("=== Performance Test ===");
-        long start = System.currentTimeMillis();
-        int iterations = 100;
-        for (int i = 0; i < iterations; i++) {
-            model.embed(query1, poolingType);
-        }
-        long elapsed = System.currentTimeMillis() - start;
-        double avgTime = (double) elapsed / iterations;
-        System.out.println("Generated " + iterations + " embeddings in " + elapsed + "ms");
-        System.out.println("Average time per embedding: " + String.format("%.2f", avgTime) + "ms");
-        System.out.println();
-        
-        System.out.println("=== Test Complete ===");
+        System.out.println(String.format(Locale.ROOT, "Value range: [%.6f, %.6f]", min, max));
+        System.out.println(String.format(Locale.ROOT, "Mean value: %.6f", mean));
     }
 }
-

--- a/jlama-core/src/main/java/com/github/tjake/jlama/examples/LeafModelExample.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/examples/LeafModelExample.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 T Jake Luciani
+ *
+ * The Jlama Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.tjake.jlama.examples;
+
+import com.github.tjake.jlama.math.VectorMath;
+import com.github.tjake.jlama.model.AbstractModel;
+import com.github.tjake.jlama.model.ModelSupport;
+import com.github.tjake.jlama.model.functions.Generator;
+import com.github.tjake.jlama.safetensors.DType;
+import com.github.tjake.jlama.safetensors.SafeTensorSupport;
+
+import java.io.File;
+
+/**
+ * Example demonstrating how to use the LEAF embedding model (MongoDB/mdbr-leaf-ir) with Jlama.
+ * 
+ * The LEAF model is a compact 6-layer, 384-dimensional BERT-based embedding model
+ * optimized for information retrieval tasks.
+ * 
+ * Usage:
+ *   java -cp ... com.github.tjake.jlama.examples.LeafModelExample [model-directory]
+ * 
+ * If model-directory is not provided, it will attempt to download the model from HuggingFace.
+ */
+public class LeafModelExample {
+    
+    public static void main(String[] args) throws Exception {
+        String modelName = "MongoDB/mdbr-leaf-ir";
+        String workingDirectory = args.length > 0 ? args[0] : "./models";
+        
+        System.out.println("=== LEAF Model Integration Test ===");
+        System.out.println("Model: " + modelName);
+        System.out.println("Working directory: " + workingDirectory);
+        System.out.println();
+        
+        // Download the LEAF model or use existing if already downloaded
+        System.out.println("Downloading or locating LEAF model...");
+        File localModelPath = SafeTensorSupport.maybeDownloadModel(workingDirectory, modelName);
+        System.out.println("Model located at: " + localModelPath.getAbsolutePath());
+        System.out.println();
+        
+        // Load as embedding model
+        System.out.println("Loading model...");
+        AbstractModel model = ModelSupport.loadEmbeddingModel(localModelPath, DType.F32, DType.F32);
+        System.out.println("Model loaded successfully!");
+        System.out.println("Embedding dimensions: " + model.getConfig().embeddingLength);
+        System.out.println("Expected: 384");
+        System.out.println();
+        
+        if (model.getConfig().embeddingLength != 384) {
+            System.err.println("WARNING: Expected 384 dimensions but got " + model.getConfig().embeddingLength);
+        }
+        
+        // Test embedding generation with AVG pooling (LEAF doesn't have a pooler layer)
+        System.out.println("=== Testing Embedding Generation ===");
+        String query1 = "What is artificial intelligence?";
+        // LEAF model doesn't have a pooler layer, so we use AVG pooling
+        Generator.PoolingType poolingType = Generator.PoolingType.AVG;
+        float[] embedding1 = model.embed(query1, poolingType);
+        System.out.println("Query: " + query1);
+        System.out.println("Using AVG pooling (LEAF model doesn't have pooler layer)");
+        System.out.println("Embedding dimension: " + embedding1.length);
+        
+        // Verify embedding values are finite and not all zeros
+        boolean hasNonZero = false;
+        boolean allFinite = true;
+        float min = Float.MAX_VALUE;
+        float max = Float.MIN_VALUE;
+        for (float v : embedding1) {
+            if (v != 0.0f) hasNonZero = true;
+            if (!Float.isFinite(v)) allFinite = false;
+            if (v < min) min = v;
+            if (v > max) max = v;
+        }
+        System.out.println("Has non-zero values: " + hasNonZero);
+        System.out.println("All values finite: " + allFinite);
+        System.out.println("Value range: [" + min + ", " + max + "]");
+        System.out.println();
+        
+        // Test similarity between related texts
+        System.out.println("=== Testing Semantic Similarity ===");
+        String query2 = "Define artificial intelligence";
+        String query3 = "What is the weather today?";
+        float[] embedding2 = model.embed(query2, poolingType);
+        float[] embedding3 = model.embed(query3, poolingType);
+        
+        float similarity12 = VectorMath.cosineSimilarity(embedding1, embedding2);
+        float similarity13 = VectorMath.cosineSimilarity(embedding1, embedding3);
+        
+        System.out.println("Query 1: " + query1);
+        System.out.println("Query 2: " + query2);
+        System.out.println("Query 3: " + query3);
+        System.out.println();
+        System.out.println("Similarity between Query 1 and Query 2: " + String.format("%.4f", similarity12));
+        System.out.println("Similarity between Query 1 and Query 3: " + String.format("%.4f", similarity13));
+        System.out.println();
+        
+        if (similarity12 > similarity13) {
+            System.out.println("✓ Related queries have higher similarity (as expected)");
+        } else {
+            System.out.println("⚠ WARNING: Related queries should have higher similarity");
+        }
+        System.out.println();
+        
+        // Test with information retrieval examples
+        System.out.println("=== Information Retrieval Test ===");
+        String base = "MongoDB is a NoSQL database";
+        String[] examples = new String[] {
+            "MongoDB stores data in documents",
+            "PostgreSQL is a relational database",
+            "The cat sat on the mat",
+            "NoSQL databases are non-relational",
+            "MongoDB uses BSON format"
+        };
+        
+        float[] baseEmbedding = model.embed(base, poolingType);
+        float maxSimilarity = 0.0f;
+        String bestMatch = "";
+        int bestIndex = -1;
+        
+        System.out.println("Base query: " + base);
+        System.out.println();
+        for (int i = 0; i < examples.length; i++) {
+            float[] exampleEmbedding = model.embed(examples[i], poolingType);
+            float similarity = VectorMath.cosineSimilarity(baseEmbedding, exampleEmbedding);
+            System.out.println(String.format("  [%d] Similarity: %.4f - %s", i, similarity, examples[i]));
+            if (similarity > maxSimilarity) {
+                maxSimilarity = similarity;
+                bestMatch = examples[i];
+                bestIndex = i;
+            }
+        }
+        System.out.println();
+        System.out.println("Best match: [" + bestIndex + "] " + bestMatch + " (similarity: " + String.format("%.4f", maxSimilarity) + ")");
+        
+        // The best match should be one of the MongoDB-related examples (indices 0, 3, or 4)
+        if (bestIndex == 0 || bestIndex == 3 || bestIndex == 4) {
+            System.out.println("✓ Best match is MongoDB-related (as expected)");
+        } else {
+            System.out.println("⚠ WARNING: Best match should be MongoDB-related");
+        }
+        System.out.println();
+        
+        // Performance test
+        System.out.println("=== Performance Test ===");
+        long start = System.currentTimeMillis();
+        int iterations = 100;
+        for (int i = 0; i < iterations; i++) {
+            model.embed(query1, poolingType);
+        }
+        long elapsed = System.currentTimeMillis() - start;
+        double avgTime = (double) elapsed / iterations;
+        System.out.println("Generated " + iterations + " embeddings in " + elapsed + "ms");
+        System.out.println("Average time per embedding: " + String.format("%.2f", avgTime) + "ms");
+        System.out.println();
+        
+        System.out.println("=== Test Complete ===");
+    }
+}
+

--- a/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModel.java
+++ b/jlama-core/src/main/java/com/github/tjake/jlama/model/bert/BertModel.java
@@ -151,6 +151,10 @@ public class BertModel extends AbstractModel {
 
     @Override
     protected PoolingLayer loadPoolingWeights() {
+        // Return null if pooler weights are not present, allowing AVG pooling to be used instead
+        if (!weights.isWeightPresent("pooler.dense.weight") && !weights.isWeightPresent("bert.pooler.dense.weight")) {
+            return null;
+        }
 
         final AbstractTensor poolerDenseWeight = loadWeight("pooler.dense.weight");
         final AbstractTensor poolerDenseBias = loadWeight("pooler.dense.bias");

--- a/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestModels.java
+++ b/jlama-tests/src/test/java/com/github/tjake/jlama/model/TestModels.java
@@ -385,6 +385,101 @@ public class TestModels {
         logger.info("took {} seconds, {}ms per emb", elapsed / 1000f, elapsed / 1000f);
     }
 
+    @Test
+    public void LeafModelRun() throws Exception {
+        String modelName = "MongoDB/mdbr-leaf-ir";
+        String workingDirectory = "./models";
+
+        // Download the LEAF model or use existing if already downloaded
+        File localModelPath = SafeTensorSupport.maybeDownloadModel(workingDirectory, modelName);
+        logger.info("Using LEAF model from: {}", localModelPath);
+
+        // Load as embedding model
+        AbstractModel model = ModelSupport.loadEmbeddingModel(localModelPath, DType.F32, DType.F32);
+
+        // Verify model configuration - LEAF should have 384 dimensions
+        Assert.assertEquals("LEAF model should have 384 embedding dimensions", 384, model.getConfig().embeddingLength);
+
+        // Test embedding generation with AVG pooling (LEAF doesn't have a pooler layer)
+        String query1 = "What is artificial intelligence?";
+        float[] embedding1 = model.embed(query1, Generator.PoolingType.AVG);
+        Assert.assertEquals("Embedding should have 384 dimensions", 384, embedding1.length);
+        logger.info("Generated embedding for '{}' with AVG pooling, dimension: {}", query1, embedding1.length);
+
+        // Verify embedding values are finite and not all zeros
+        boolean hasNonZero = false;
+        boolean allFinite = true;
+        for (float v : embedding1) {
+            if (v != 0.0f) hasNonZero = true;
+            if (!Float.isFinite(v)) allFinite = false;
+        }
+        Assert.assertTrue("Embedding should have non-zero values", hasNonZero);
+        Assert.assertTrue("All embedding values should be finite", allFinite);
+
+        // Test similarity between related texts
+        String query2 = "Define artificial intelligence";
+        String query3 = "What is the weather today?";
+        
+        // LEAF model uses AVG pooling (no pooler layer)
+        Generator.PoolingType poolingType = Generator.PoolingType.AVG;
+        float[] embedding2 = model.embed(query2, poolingType);
+        float[] embedding3 = model.embed(query3, poolingType);
+
+        float similarity12 = VectorMath.cosineSimilarity(embedding1, embedding2);
+        float similarity13 = VectorMath.cosineSimilarity(embedding1, embedding3);
+
+        logger.info("Similarity between '{}' and '{}': {:.4f}", query1, query2, String.format("%.4f", similarity12));
+        logger.info("Similarity between '{}' and '{}': {:.4f}", query1, query3, String.format("%.4f", similarity13));
+
+        // Related queries should have higher similarity than unrelated ones
+        Assert.assertTrue(
+            String.format("Related queries should have higher similarity (%.4f > %.4f)", similarity12, similarity13),
+            similarity12 > similarity13
+        );
+
+        // Test with information retrieval examples
+        String base = "MongoDB is a NoSQL database";
+        String[] examples = new String[] {
+            "MongoDB stores data in documents",
+            "PostgreSQL is a relational database",
+            "The cat sat on the mat",
+            "NoSQL databases are non-relational",
+            "MongoDB uses BSON format"
+        };
+
+        float[] baseEmbedding = model.embed(base, poolingType);
+        float maxSimilarity = 0.0f;
+        String bestMatch = "";
+        int bestIndex = -1;
+
+        for (int i = 0; i < examples.length; i++) {
+            float[] exampleEmbedding = model.embed(examples[i], poolingType);
+            float similarity = VectorMath.cosineSimilarity(baseEmbedding, exampleEmbedding);
+            logger.info("Similarity between '{}' and '{}': {}", base, examples[i], String.format("%.4f", similarity));
+            if (similarity > maxSimilarity) {
+                maxSimilarity = similarity;
+                bestMatch = examples[i];
+                bestIndex = i;
+            }
+        }
+
+        logger.info("Best match for '{}' is '{}' with similarity {}", base, bestMatch, String.format("%.4f", maxSimilarity));
+
+        // The best match should be one of the MongoDB-related examples (indices 0, 3, or 4)
+        Assert.assertTrue(
+            "Best match should be MongoDB-related",
+            bestIndex == 0 || bestIndex == 3 || bestIndex == 4
+        );
+
+        // Performance test
+        long start = System.currentTimeMillis();
+        int iterations = 100;
+        VectorMath.pfor(0, iterations, i -> model.embed(query1, poolingType));
+        long elapsed = System.currentTimeMillis() - start;
+        double avgTime = (double) elapsed / iterations;
+        logger.info("Performance: {} embeddings in {}ms, avg {}ms per embedding", iterations, elapsed, String.format("%.2f", avgTime));
+    }
+
     private BiConsumer<String, Float> makeOutHandler() {
         PrintWriter out;
         BiConsumer<String, Float> outCallback;

--- a/run-leaf-example.sh
+++ b/run-leaf-example.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Script to run the LEAF model example
+
+cd "$(dirname "$0")/jlama-core" || exit 1
+
+# Build if needed
+if [ ! -f "target/jlama-core-0.9.0-beta.jar" ]; then
+    echo "Building jlama-core..."
+    mvn package -DskipTests || exit 1
+fi
+
+# Copy dependencies if needed
+if [ ! -d "target/dependency" ] || [ -z "$(ls -A target/dependency/*.jar 2>/dev/null)" ]; then
+    echo "Copying dependencies..."
+    # Get absolute path to jlama-core directory before changing
+    JLAMA_CORE_DIR="$(pwd)"
+    cd ..
+    # Use absolute path to avoid nested directory issues when running from parent
+    mvn dependency:copy-dependencies -pl jlama-core -DoutputDirectory="$JLAMA_CORE_DIR/target/dependency" || exit 1
+    cd "$JLAMA_CORE_DIR" || exit 1
+fi
+
+# Build classpath - explicitly add all dependency jars
+CP="target/jlama-core-0.9.0-beta.jar"
+DEPENDENCY_COUNT=0
+if [ -d "target/dependency" ]; then
+    # Add each jar explicitly to avoid wildcard expansion issues
+    for jar in target/dependency/*.jar; do
+        if [ -f "$jar" ]; then
+            CP="$CP:$jar"
+            DEPENDENCY_COUNT=$((DEPENDENCY_COUNT + 1))
+        fi
+    done
+fi
+
+if [ "$DEPENDENCY_COUNT" -eq 0 ]; then
+    echo "ERROR: No dependency jars found in target/dependency/"
+    exit 1
+fi
+
+echo "Found $DEPENDENCY_COUNT dependency jars"
+
+# Run the example
+echo "Running LEAF model example..."
+echo "Classpath: $CP"
+echo ""
+java -cp "$CP" \
+    --add-modules jdk.incubator.vector \
+    --enable-preview \
+    com.github.tjake.jlama.examples.LeafModelExample "$@"
+


### PR DESCRIPTION
# Add LEAF Embedding Model Support

Adds support for the MongoDB LEAF embedding model (`MongoDB/mdbr-leaf-ir`), a compact 6-layer, 384-dimensional BERT-based model optimized for information retrieval.

## Changes
- Added `LeafModelExample.java` with CLI flags for normalization, batch size, and parallel processing
- Added `run-leaf-example.sh` script
- Updated README with LEAF documentation and semantic search use cases
- Added `TestModels.LeafModelRun()` test